### PR TITLE
Automatic deploy to jmeter plugins

### DIFF
--- a/.github/build_release_json.sh
+++ b/.github/build_release_json.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-#--------------Environment variables------------------#
 RELEASE_VERSION=$1
 PLUGIN_ARTIFACT_NAME=$2
 PLUGIN_REPOSITORY_NAME=$3
 RELEASES_FILE="releases.json"
-#-----------------------------------------------------#
-
 ARTIFACT_URLS_FILE=".github/artifact_urls.temp"
 
 get_current_version_details() {

--- a/.github/build_release_json.sh
+++ b/.github/build_release_json.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+#--------------Environment variables------------------#
+RELEASE_VERSION=$1
+PLUGIN_ARTIFACT_NAME=$2
+PLUGIN_REPOSITORY_NAME=$3
+RELEASES_FILE="releases.json"
+#-----------------------------------------------------#
+
+ARTIFACT_URLS_FILE=".github/artifact_urls.temp"
+
+get_current_version_details() {
+    jq --arg version "$RELEASE_VERSION" '.[] | select(.version == ($version | tonumber))' "$RELEASES_FILE"
+}
+
+get_dependencies() {
+    echo "$1" | jq -r '.dependencies[]'
+}
+
+get_artifacts_urls() {
+    gh release view -R Blazemeter/$PLUGIN_REPOSITORY_NAME \
+        "v$RELEASE_VERSION" --json assets -q '.assets.[].url' > "$ARTIFACT_URLS_FILE"
+}
+
+find_url_for_dependency() {
+    grep -F "$1" "$ARTIFACT_URLS_FILE"
+}
+
+build_libs() {
+    get_artifacts_urls
+    local dependencies="$1"
+    local undera_dependencies="{}"
+
+    while IFS= read -r dependency; do
+        name=$(echo "$dependency" | cut -d'>' -f1)
+        version=$(echo "$dependency" | cut -d'=' -f2)
+        search_result=$(find_url_for_dependency "$name")
+
+        if [ -n "$search_result" ]; then
+            undera_dependencies=$(echo "$undera_dependencies" | jq --arg dep "$dependency" --arg url "$search_result" '. + {($dep): $url}')
+        else
+            echo "Dependency $name>=$version not found in artifacts download url"
+        fi
+    done <<< "$dependencies"
+
+    echo "$undera_dependencies"
+}
+
+create_release_object() {
+    local version="$1"
+    local what_is_new="$2"
+    local plugin_url="$3"
+    local dependencies="$4"
+    jq -n --arg version "$version" --arg what_is_new "$what_is_new" \
+        --arg plugin_url "$plugin_url" --argjson libs "$dependencies" \
+        '{($version): {changes: $what_is_new, downloadUrl: $plugin_url, libs: $libs, "depends": ["bzm-repositories"]}}'
+}
+
+
+current_version_details=$(get_current_version_details)
+current_version_dependencies=$(get_dependencies "$current_version_details")
+
+libs=$(build_libs "$current_version_dependencies")
+
+plugin_url=$(find_url_for_dependency "$PLUGIN_ARTIFACT_NAME")
+what_is_new=$(echo "$current_version_details" | jq -r '.what_is_new')
+
+release_object=$(create_release_object "$RELEASE_VERSION" "$what_is_new" "$plugin_url" "$libs")
+rm -rf $ARTIFACT_URLS_FILE
+echo "$release_object" | jq -c '.'

--- a/.github/workflows/publish_to_jmeter_plugins.yaml
+++ b/.github/workflows/publish_to_jmeter_plugins.yaml
@@ -1,0 +1,100 @@
+name: release
+on: workflow_dispatch
+
+env:
+  PLUGIN_ARTIFACT_NAME: "jmeter-bzm-correlation-recorder"
+  PLUGIN_REPOSITORY_NAME: "CorrelationRecorder"
+  JMETER_PLUGINS_PLUGIN_KEY: "bzm-siebel"
+  FILE_PATH: "site/dat/repo/blazemeter.json"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: blazemeter_test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            releases.json
+            .github/build_release_json.sh
+            .github/get_artifacts_urls.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Get latest release version
+        id: version
+        run: |
+          ls -la
+          echo "$GH_TOKEN" | gh auth login --with-token
+          echo "RELEASE_VERSION=$(gh release view -R Blazemeter/CorrelationRecorder --json name -q '.name')"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: Baraujo25/jmeter-plugins
+          path: jmeter-plugins
+          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure Git
+        working-directory: ./jmeter-plugins
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+
+      - name: Set remotes
+        working-directory: ./jmeter-plugins
+        run: |
+          git remote set-url origin $FORKED_REPO_SSH
+          git remote add upstream $UPSTREAM_REPO_SSH
+        env:
+          FORKED_REPO_SSH: "git@github.com:Baraujo25/jmeter-plugins.git"
+          UPSTREAM_REPO_SSH: "git@github.com:Abstracta/jmeter-plugins.git"
+
+      - name: Create name for branch release
+        working-directory: ./jmeter-plugins
+        run: |
+          echo "BRANCH_NAME=$PLUGIN_ARTIFACT_NAME-v$RELEASE_VERSION" >> $GITHUB_ENV
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
+      - name: "Create branch: ${{ env.BRANCH_NAME }}"
+        working-directory: ./jmeter-plugins
+        run: |
+          git checkout -b $BRANCH_NAME
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+
+      - name: Update ${{ env.BRANCH_NAME }} from upstream
+        working-directory: ./jmeter-plugins
+        run: |
+          git fetch upstream
+          git merge upstream/master --allow-unrelated-histories || git merge --abort
+
+      - name: Build and save json release object
+        run: |
+          echo "NEW_VERSION_OBJECT=$(bash .github/build_release_json.sh \
+               $RELEASE_VERSION \
+               $PLUGIN_ARTIFACT_NAME \
+               $PLUGIN_REPOSITORY_NAME)" \
+               >> $GITHUB_ENV
+          echo "${{ env.NEW_VERSION_OBJECT }}"
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Update jmeter-plugins JSON File
+        working-directory: ./jmeter-plugins
+        run: |
+          jq --argjson newVersion "$NEW_VERSION_OBJECT" \
+             --arg plugin_key "$JMETER_PLUGINS_PLUGIN_KEY" \
+              'map(if .id == "$plugin_key" then .versions += $newVersion else . end)' \
+              $FILE_PATH > tmp.json
+          mv tmp.json $FILE_PATH
+      - name: Commit and push changes
+        working-directory: ./jmeter-plugins
+        run: |
+          git add $FILE_PATH
+          git commit -m "$PLUGIN_REPOSITORY_NAME v$RELEASE_VERSION release"
+          echo "push to origin"
+          git push -u origin $BRANCH_NAME

--- a/.github/workflows/publish_to_jmeter_plugins.yaml
+++ b/.github/workflows/publish_to_jmeter_plugins.yaml
@@ -112,3 +112,4 @@ jobs:
             --head $FORKED_REPO_USER:$BRANCH_NAME \
             --base master \
             --repo $UPSTREAM_REPO_USER/$JMETER_PLUGINS_NAME
+            --draft

--- a/.github/workflows/publish_to_jmeter_plugins.yaml
+++ b/.github/workflows/publish_to_jmeter_plugins.yaml
@@ -1,35 +1,44 @@
-name: release
+name: Deploy to JMeter Plugins
 on: workflow_dispatch
 
 env:
   PLUGIN_ARTIFACT_NAME: "jmeter-bzm-correlation-recorder"
-  PLUGIN_REPOSITORY_NAME: "CorrelationRecorder"
+  PLUGIN_REPOSITORY_NAME: CorrelationRecorder
   JMETER_PLUGINS_PLUGIN_KEY: "bzm-siebel"
   FILE_PATH: "site/dat/repo/blazemeter.json"
+  FORKED_REPO_SSH: "git@github.com:Abstracta/jmeter-plugins.git"
+  UPSTREAM_REPO_SSH: "git@github.com:undera/jmeter-plugins.git"
+  FORKED_REPO_USER: Abstracta
+  UPSTREAM_REPO_USER: undera
+  JMETER_PLUGINS_NAME: jmeter-plugins
 jobs:
   release:
     runs-on: ubuntu-latest
     concurrency: blazemeter_test
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout ${{ env.PLUGIN_REPOSITORY_NAME }}
+        uses: actions/checkout@v4
         with:
           sparse-checkout: |
             releases.json
             .github/build_release_json.sh
-            .github/get_artifacts_urls.sh
           sparse-checkout-cone-mode: false
 
       - name: Get latest release version
         id: version
         run: |
-          ls -la
-          echo "$GH_TOKEN" | gh auth login --with-token
-          echo "RELEASE_VERSION=$(gh release view -R Blazemeter/CorrelationRecorder --json name -q '.name')"
+          echo "${{ secrets.GH_TOKEN }}" | gh auth login --with-token
+          RELEASE_VERSION=$(gh release view -R Blazemeter/$PLUGIN_REPOSITORY_NAME --json name -q '.name')
+          if [ -z "$RELEASE_VERSION" ]; then
+              echo "No release version found"
+              exit 1
+          fi
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
-      - name: Checkout repository
+      - name: Checkout forked jmeter-plugins repository
         uses: actions/checkout@v4
         with:
-          repository: Baraujo25/jmeter-plugins
+          repository: ${{ env.FORKED_REPO_USER }}/${{ env.JMETER_PLUGINS_NAME }}
           path: jmeter-plugins
           token: ${{ secrets.GH_TOKEN }}
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -47,23 +56,16 @@ jobs:
         run: |
           git remote set-url origin $FORKED_REPO_SSH
           git remote add upstream $UPSTREAM_REPO_SSH
-        env:
-          FORKED_REPO_SSH: "git@github.com:Baraujo25/jmeter-plugins.git"
-          UPSTREAM_REPO_SSH: "git@github.com:Abstracta/jmeter-plugins.git"
 
       - name: Create name for branch release
         working-directory: ./jmeter-plugins
         run: |
           echo "BRANCH_NAME=$PLUGIN_ARTIFACT_NAME-v$RELEASE_VERSION" >> $GITHUB_ENV
-        env:
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
 
       - name: "Create branch: ${{ env.BRANCH_NAME }}"
         working-directory: ./jmeter-plugins
         run: |
           git checkout -b $BRANCH_NAME
-        env:
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
 
       - name: Update ${{ env.BRANCH_NAME }} from upstream
         working-directory: ./jmeter-plugins
@@ -73,14 +75,17 @@ jobs:
 
       - name: Build and save json release object
         run: |
-          echo "NEW_VERSION_OBJECT=$(bash .github/build_release_json.sh \
+          NEW_VERSION_OBJECT=$(bash .github/build_release_json.sh \
                $RELEASE_VERSION \
                $PLUGIN_ARTIFACT_NAME \
-               $PLUGIN_REPOSITORY_NAME)" \
-               >> $GITHUB_ENV
-          echo "${{ env.NEW_VERSION_OBJECT }}"
+               $PLUGIN_REPOSITORY_NAME)
+
+          if [ -z "$NEW_VERSION_OBJECT" ]; then
+              echo "JSON Relase object is empty. Something might gone wrong while generating it."
+              exit 1
+          fi
+          echo "NEW_VERSION_OBJECT=$NEW_VERSION_OBJECT" >> $GITHUB_ENV
         env:
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Update jmeter-plugins JSON File
@@ -88,13 +93,22 @@ jobs:
         run: |
           jq --argjson newVersion "$NEW_VERSION_OBJECT" \
              --arg plugin_key "$JMETER_PLUGINS_PLUGIN_KEY" \
-              'map(if .id == "$plugin_key" then .versions += $newVersion else . end)' \
+              'map(if .id == $plugin_key then .versions += $newVersion else . end)' \
               $FILE_PATH > tmp.json
           mv tmp.json $FILE_PATH
+
       - name: Commit and push changes
         working-directory: ./jmeter-plugins
         run: |
           git add $FILE_PATH
           git commit -m "$PLUGIN_REPOSITORY_NAME v$RELEASE_VERSION release"
-          echo "push to origin"
           git push -u origin $BRANCH_NAME
+
+      - name: "Open PR in ${{ env.UPSTREAM_REPO_USER }}/${{ env.JMETER_PLUGINS_NAME }}"
+        run: |
+          gh pr create -R $FORKED_REPO_USER/$JMETER_PLUGINS_NAME \
+            --title "$PLUGIN_REPOSITORY_NAME v$RELEASE_VERSION" \
+            --body "Automated release process" \
+            --head $FORKED_REPO_USER:$BRANCH_NAME \
+            --base master \
+            --repo $UPSTREAM_REPO_USER/$JMETER_PLUGINS_NAME


### PR DESCRIPTION
The reason behind multiple steps is in order to validate that each of every step is executing as expected. In case something fails, it's more traceable this way. Anyway, I'm open to suggestions.
Here is a view once is executed:
<img width="1098" alt="image" src="https://github.com/Blazemeter/CorrelationRecorder/assets/48018971/eff9630f-e56b-4a00-b7a8-096fddb702b9">
